### PR TITLE
[FEAT]: Create role wireguard

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ./roles

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,8 +1,0 @@
-services:
-  ansible:
-    container_name: ansible
-    image: alpine/ansible
-    volumes:
-      - type: bind
-        source: .
-        target: /main

--- a/group_vars/wg/wg.yaml
+++ b/group_vars/wg/wg.yaml
@@ -1,0 +1,11 @@
+# WireGuard env
+### Server 
+server_interface_addr: "10.200.40.1/24"
+server_interface_port: 55555
+
+### User
+user_interface_addr: "10.200.40.2/32"
+user_interface_dns: "1.1.1.1"
+allowedIPs: "0.0.0.0/0"
+
+wg_conf_dir: "~/wireguard"

--- a/inventory/example.ini
+++ b/inventory/example.ini
@@ -1,0 +1,9 @@
+[home-lab]
+ubuntu-18
+ubuntu-20
+
+[ubuntu-18]
+name-01 ansible_host=10.100.10.1
+
+[ubuntu-20]
+name-02 ansible_host=10.100.10.2

--- a/main.yaml
+++ b/main.yaml
@@ -1,8 +1,8 @@
 ---
 - name: Start playbook
-  gather_facts: false
-  hosts: test
+  gather_facts: true
+  hosts: all
   tasks:
-    - name: Timedate change
-      ansible.builtin.include_role:
-        name: timezone
+    - name: Install wireguard
+      ansible.builtin.import_role:
+        name: wireguard

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ansible-lint

--- a/roles/wireguard/README.md
+++ b/roles/wireguard/README.md
@@ -1,38 +1,72 @@
 Role Name
-=========
+# WireGuard VPN install
 
-A brief description of the role goes here.
+## DEFAULTS
+Указанны значения по умолчанию
 
-Requirements
-------------
+## TASKS
+Генерация ключей
+```
+create_keys.yaml
+```
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+Основной файл запуска
+```
+main.yml
+```
 
-Role Variables
---------------
+Файл сохранения ключей и конфигураций 
+```
+save_files.yaml
+```
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+## TEMPLATE
+Динамическое создание конфига пользователя и сохранение локально через перменную `wg_conf_dir`
+```
+user.conf.j2
+```
 
-Dependencies
-------------
+Динамическое создание конфига сервиса `wg-quick@wg0.service`
+```
+wg0.conf.j2
+```
 
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+## VAR
+### Server
+IP по умолчанию для сервера
+```
+wireguard_server_interface_addr
+```
+PORT по умолчанию для сервера
+```
+wireguard_server_interface_port
+```
+Приватный ключ сервера
+```
+wireguard_private_key
+```
 
-Example Playbook
-----------------
+### User
+IP по умолчанию для пользователя
+```
+wireguard_user_interface_addr
+```
 
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+DNS по умолчанию
+```
+wireguard_user_interface_dns
+```
 
-    - hosts: servers
-      roles:
-         - { role: username.rolename, x: 42 }
+Диапазон IP отправленые в WG
+```
+wireguard_allowedips
+```
 
-License
--------
+Локальное место хранения сгенерированного конфига
+```
+wireguard_local_conf_dir
+```
 
-BSD
-
-Author Information
-------------------
-
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+## Experemental
+### FILES
+Есть два скрипта для генерации, но они не используются в роли

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -1,2 +1,12 @@
 ---
 # defaults file for roles/wireguard
+wireguard_server_interface_addr: "10.200.40.1/24"
+wireguard_server_interface_port: "55555"
+
+wireguard_private_key: "{{ wireguard_server_private_key.stdout }}"
+
+wireguard_user_interface_addr: "10.200.40.2/32"
+wireguard_user_interface_dns: "1.1.1.1"
+wireguard_allowedips: "0.0.0.0/0"
+
+wireguard_local_conf_dir: "."

--- a/roles/wireguard/files/create_server_keys.sh
+++ b/roles/wireguard/files/create_server_keys.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Create Server keys
+server_private_key=$(wg genkey)
+server_public_key=$(server_private_key | wg pubkey)
+
+echo -e "# Server keys"
+echo "#PRIVATE: $server_private_key" >> /etc/wireguard/keys/server.key
+echo "#PUBLIC: $server_public_key" >> /etc/wireguard/keys/server.key

--- a/roles/wireguard/files/create_user_keys.sh
+++ b/roles/wireguard/files/create_user_keys.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Create User keys
+user_private_key=$(wg genkey)
+user_public_key=$(user_private_key | wg pubkey)
+
+echo -e "# User keys"
+echo "#PRIVATE: $user_private_key" >> /etc/wireguard/keys/user.key
+echo "#PUBLIC: $user_public_key" >> /etc/wireguard/keys/user.key

--- a/roles/wireguard/handlers/main.yml
+++ b/roles/wireguard/handlers/main.yml
@@ -1,2 +1,8 @@
 ---
 # handlers file for roles/wireguard
+- name: Restart service
+  ansible.builtin.systemd:
+    name: wg-quick@wg0
+    state: restarted
+    enabled: true
+    daemon_reload: true

--- a/roles/wireguard/tasks/create_keys.yaml
+++ b/roles/wireguard/tasks/create_keys.yaml
@@ -1,0 +1,18 @@
+---
+# SERVER
+- name: Generate-Keys | Server private key
+  ansible.builtin.command: wg genkey
+  register: wireguard_server_private_key
+
+- name: Generate-Keys | Server public key
+  ansible.builtin.shell: echo "{{ wireguard_server_private_key.stdout }}" | wg pubkey
+  register: wireguard_server_public_key
+
+# USER
+- name: Generate-Keys | User private key
+  ansible.builtin.command: wg genkey
+  register: wireguard_user_private_key
+
+- name: Generate-Keys | User public key
+  ansible.builtin.shell: echo "{{ wireguard_user_private_key.stdout }}" | wg pubkey
+  register: wireguard_user_public_key

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -1,2 +1,61 @@
 ---
-# tasks file for roles/wireguard
+- name: Install WireGuard
+  ansible.builtin.apt:
+    name:
+      - wireguard
+    state: present
+
+- name: Add IPv4 Forwarding
+  ansible.posix.sysctl:
+    name: net.ipv4.ip_forward
+    value: "1"
+    sysctl_set: true
+    state: present
+    reload: true
+
+- name: Create local dir for files
+  ansible.builtin.file:
+    path: "{{ wireguard_local_conf_dir }}"
+    state: directory
+    mode: "0700"
+  delegate_to: localhost
+  become: false
+
+- name: Check keys directory
+  ansible.builtin.stat:
+    path: "/etc/wireguard/keys/"
+  register: keys_dir_exist
+
+- name: Create keys at server
+  ansible.builtin.file:
+    path: "/etc/wireguard/keys/"
+    state: directory
+    mode: "0700"
+  register: create_keys_dir
+  when: not keys_dir_exist.stat.exists
+
+- name: Create keys
+  ansible.builtin.import_tasks: create_keys.yaml
+  when: create_keys_dir is changed
+  notify:
+    - Restart service
+
+- name: Save local files
+  ansible.builtin.import_tasks: save_files.yaml
+  when: create_keys_dir is changed
+
+- name: Create wg conf
+  ansible.builtin.template:
+    src: "wg0.conf.j2"
+    dest: "/etc/wireguard/wg0.conf"
+    mode: "0600"
+  when: create_keys_dir is changed
+  notify:
+    - Restart service
+
+- name: Start WireGuard service
+  ansible.builtin.systemd:
+    name: wg-quick@wg0
+    state: started
+    enabled: true
+    daemon_reload: true

--- a/roles/wireguard/tasks/save_files.yaml
+++ b/roles/wireguard/tasks/save_files.yaml
@@ -1,0 +1,43 @@
+---
+# Save files
+- name: Save to local server private key
+  ansible.builtin.copy:
+    content: "{{ wireguard_server_private_key.stdout }}"
+    dest: "{{ wireguard_local_conf_dir }}/private.key"
+    mode: "0600"
+  delegate_to: localhost
+  become: false
+
+- name: Save to local server public key
+  ansible.builtin.copy:
+    content: "{{ wireguard_server_public_key.stdout }}"
+    dest: "{{ wireguard_local_conf_dir }}/public.key"
+    mode: "0600"
+  delegate_to: localhost
+  become: false
+
+- name: Save to local user private key
+  ansible.builtin.copy:
+    content: "{{ wireguard_user_private_key.stdout }}"
+    dest: "{{ wireguard_local_conf_dir }}/user-priv.key"
+    mode: "0600"
+  delegate_to: localhost
+  become: false
+
+- name: Save to local user public key
+  ansible.builtin.copy:
+    content: "{{ wireguard_user_public_key.stdout }}"
+    dest: "{{ wireguard_local_conf_dir }}/user-pub.key"
+    mode: "0600"
+  delegate_to: localhost
+  become: false
+
+- name: Save to local user conf
+  ansible.builtin.template:
+    src: "user.conf.j2"
+    dest: "{{ wireguard_local_conf_dir }}/user.conf"
+    backup: true
+    mode: "0600"
+  delegate_to: localhost
+  become: false
+

--- a/roles/wireguard/templates/user.conf.j2
+++ b/roles/wireguard/templates/user.conf.j2
@@ -1,0 +1,12 @@
+{% for host in groups ['wireguard'] %}
+[Interface]
+PrivateKey = {{ wireguard_user_private_key.stdout }}
+Address = {{ wireguard_user_interface_addr }}
+DNS = {{ wireguard_user_interface_dns }}
+
+[Peer]
+PublicKey = {{ wireguard_server_public_key.stdout }}
+AllowedIPs = {{ wireguard_allowedips }}
+Endpoint = {{ hostvars[host]['ansible_all_ipv4_addresses'][0] }}:{{ wireguard_server_interface_port }}
+PersistentKeepalive = 15
+{% endfor %}

--- a/roles/wireguard/templates/wg0.conf.j2
+++ b/roles/wireguard/templates/wg0.conf.j2
@@ -1,0 +1,10 @@
+[Interface]
+Address = {{ wireguard_server_interface_addr }}
+ListenPort = {{ wireguard_server_interface_port }}
+PrivateKey = {{ wireguard_server_public_key.stdout }}
+PostUp   = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE
+
+[Peer]
+PublicKey = {{ wireguard_user_public_key.stdout }}
+AllowedIPs = {{ wireguard_user_interface_addr }}

--- a/roles/wireguard/tests/inventory
+++ b/roles/wireguard/tests/inventory
@@ -1,2 +1,0 @@
-localhost
-

--- a/roles/wireguard/vars/main.yml
+++ b/roles/wireguard/vars/main.yml
@@ -1,2 +1,12 @@
 ---
 # vars file for roles/wireguard
+wireguard_server_interface_addr: "{{ server_interface_addr }}"
+wireguard_server_interface_port: "{{ server_interface_port }}"
+
+wireguard_private_key: "{{ wireguard_server_private_key.stdout }}"
+
+wireguard_user_interface_addr: "{{ user_interface_addr }}"
+wireguard_user_interface_dns: "{{ user_interface_dns }}"
+wireguard_allowedips: "{{ allowedIPs }}"
+
+wireguard_local_conf_dir: "{{ wg_conf_dir }}"


### PR DESCRIPTION
# WireGuard Role

### Как запустить?
- Основная роль находится в `role/wireguard`
- Переменный для запуска `group_vars/wg`

### Что добавлено?
- Напсана роль для установки WireGuard VPN на сервера deb

### Почему это нужно?
- Простота развертывания WG

### Как протестировать?
- Основная команда использовалась в локальном окружении
```
ansible-playbook -i inventory/inv.ini main.yaml -b -e "@group_vars/wg/wg.yaml"
```

### Что можно добавить?
- Поддержку WEB-UI
- Добавление новых конфигураций
